### PR TITLE
fix rapids url

### DIFF
--- a/cmake/NVBenchRapidsCMake.cmake
+++ b/cmake/NVBenchRapidsCMake.cmake
@@ -19,7 +19,7 @@
 macro(nvbench_load_rapids_cmake)
   if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/NVBENCH_RAPIDS.cmake")
     file(DOWNLOAD
-    https://$ENV{GITHUB_USER}:$ENV{GITHUB_PASS}@raw.githubusercontent.com/AMD-AI/rapids-cmake/main/RAPIDS.cmake
+      https://raw.githubusercontent.com/ROCm/rapids-cmake/branch-24.06/RAPIDS.cmake
       "${CMAKE_CURRENT_BINARY_DIR}/NVBENCH_RAPIDS.cmake"
     )
   endif()


### PR DESCRIPTION
## Description

nvBench will be used as a submodule of top-level cmake projects:

> https://github.com/flashinfer-ai/flashinfer/pull/491

So we need to make sure thirdparty dependencies are visible to all users.

We found original link is ristricted to AMD-AI users. This is not the right option. And should be fixed


## Test

<img width="990" alt="截屏2024-09-04 18 12 09" src="https://github.com/user-attachments/assets/b1087e6b-2e97-4cc3-89df-cf69ba1621e8">

